### PR TITLE
fix issue that occurs when cells are not strings

### DIFF
--- a/polymer-datatables-export.html
+++ b/polymer-datatables-export.html
@@ -35,8 +35,11 @@
       _.each( poly.data, function(row) {
         var d = [];
         _.each(keys, function(key) {
-          row[key] = row[key] || '';
-          d.push( row[key].replace(/,/g, '').replace(/^\s+|\s+$/g, '') );
+          var cellData = row[key] || '';
+          if (typeof cellData === 'string') {
+            cellData = cellData.replace(/,/g, '').replace(/^\s+|\s+$/g, '');
+          }
+          d.push( cellData );
         });
         poly.exportData.push(d);
       });


### PR DESCRIPTION
we were trying to do regex string.replace - which throws an error if the cell contains a number instead of a string
